### PR TITLE
fix: always send @ucsd.edu email to SLH

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,7 +2,7 @@ import { URLExt } from '@jupyterlab/coreutils';
 
 import { ServerConnection } from '@jupyterlab/services';
 
-import { getStudentUsernameFromUrl, isProduction } from '@/utils';
+import { getStudentEmailFromUrl, isProduction } from '@/utils';
 
 export interface IAskTutorParams {
   student_question: string;
@@ -57,7 +57,7 @@ export async function askTutor({
 }: IAskTutorParams): Promise<ITutorResponse> {
   const url = 'https://slh-backend-v2-api-dev.slh.ucsd.edu/api/dsc10/ask';
 
-  const username = isProduction() ? getStudentUsernameFromUrl() : 'dsc10-test';
+  const studentEmail = getStudentEmailFromUrl();
 
   // In production (datahub), we DON'T use an authorization token since SLH
   // whitelists all datahub requests. Instead, we need to include a
@@ -78,9 +78,7 @@ export async function askTutor({
     class_id: 'ca000000-0000-0000-0001-000000000001',
     assignment_id: 'ca000000-0000-0000-0002-000000000001',
     question_id: 'ca000000-0000-0000-0004-000000000001',
-    // technically we're sending a username, not an email, but the most
-    // important thing is that it's unique to the student
-    student_email: username,
+    student_email: studentEmail,
     student_question: student_question,
     notebook_json: notebook_json || '',
     prompt: prompt || ''

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,26 +18,28 @@ export function isProduction(): boolean {
 /**
  * Parses the student email from the window location URL.
  * Expected format: https://datahub.ucsd.edu/user/<username>/...
- * Returns <username>
+ * Returns <username>@ucsd.edu
  */
-export function getStudentUsernameFromUrl(
-  defaultUsername: string = 'dsc10-test'
+export function getStudentEmailFromUrl(
+  defaultEmail: string = 'dsc10-test@ucsd.edu'
 ): string {
   try {
-    // Parse email from URL: https://datahub.ucsd.edu/user/sel011/lab?
+    // Parse username from URL: https://datahub.ucsd.edu/user/sel011/lab?
     // We expect the path to be /user/<username>/...
     const match = window.location.pathname.match(/\/user\/([^/]+)/);
     if (match && match[1]) {
-      return match[1];
+      return `${match[1]}@ucsd.edu`;
     } else {
-      console.error(
-        'Could not parse student username from URL:',
-        window.location.pathname
-      );
+      if (isProduction()) {
+        console.error(
+          'Could not parse student email from URL:',
+          window.location.pathname
+        );
+      }
     }
   } catch (e) {
-    console.error('Error parsing student username from URL:', e);
+    console.error('Error parsing student email from URL:', e);
   }
 
-  return defaultUsername;
+  return defaultEmail;
 }


### PR DESCRIPTION
before, we were sending usernames to the SLH which didn't have the
@ucsd.edu suffix. for some reason, this only caused issues when sending
requests from localhost:8888 but not localhost:9999 (which is what i was
using and why i didn't catch this until now.)

this fixes that issue by always sending @ucsd.edu emails to the SLH.
