### PR TITLE
fix: set min-width of app widget properly

### DIFF
--- a/src/AppWidget.tsx
+++ b/src/AppWidget.tsx
@@ -16,6 +16,10 @@ import { type Widget } from '@lumino/widgets';
 import Chat from '@/components/Chat';
 import { NotebookProvider } from '@/contexts/NotebookContext';
 
+// set the min-width to be same as the other default jupyterlab right sidebar
+// widgets (the property inspector and debugger, as of this writing)
+const APP_MIN_WIDTH = '250px';
+
 function App() {
   return (
     <div
@@ -33,11 +37,30 @@ export function createAppWidget({
 }: {
   notebookTracker: INotebookTracker;
 }): Widget {
-  return ReactWidget.create(
+  const widget = ReactWidget.create(
     <StrictMode>
       <NotebookProvider notebookTracker={notebookTracker}>
         <App />
       </NotebookProvider>
     </StrictMode>
   );
+
+  // sam: it took me forever to figure out how to set the min-width of the
+  // widget properly. it turns out that you can't set the min-width of the
+  // MainAreaWidget in index.ts because
+  // @lumino/widgets/boxlayout.ts:BoxLayout._fit() reads the min-width from the
+  // CHILDREN of the widget inside MainAreaWidget, then overrides the min-width
+  // of the MainAreaWidget itself. so even when i was setting the min-width
+  // of the MainAreaWidget, it would get overridden by the min-width of the
+  // children.
+  //
+  // we also can't set the min-width in the App component since that gets
+  // created dynamically after the widget attaches, so when i was trying to set
+  // the min-width of App, the min-width on initial load would still be 0px.
+  //
+  // basically, this is our ONLY chance to set the min-width of the widget and
+  // have lumino respect it!
+  widget.node.style.minWidth = APP_MIN_WIDTH;
+
+  return widget;
 }


### PR DESCRIPTION
closes https://github.com/dstl-lab/dsc10-tutor-jlab/issues/8

before, the tutor sidebar pane could get dragged to 0 width if you
dragged the edge of the sidebar all the way to the right. even worse,
the sidebar pane could open to 0 width, which means that a regular user
would just think that the tutor was broken.

now, the sidebar can't get resized below 250px. figuring this out took
me forever, see the comments in AppWidget.tsx for the backstory.

https://github.com/user-attachments/assets/4816d8c8-9490-42ae-ad2c-d802b345a960