### PR TITLE
feat: Inserting code cell into Notebook

### DIFF
--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -1,4 +1,3 @@
-import { useNotebook } from '@/contexts/NotebookContext';
 import { cn } from '@/utils';
 import * as React from 'react';
 import Markdown from './Markdown';
@@ -21,7 +20,6 @@ export default function ChatMessages({
   messages,
   isWaiting = false
 }: IChatMessagesProps) {
-  const notebook = useNotebook();
   if (messages.length === 0) {
     return (
       <div className="flex flex-1 flex-col gap-2 overflow-y-auto">

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -9,52 +9,6 @@ type MarkdownProps = {
   enableInsertForPython?: boolean;
 };
 
-// Code block & inline code renderer
-function CodeComponent({
-  inline,
-  className,
-  children
-}: {
-  inline?: boolean;
-  className?: string;
-  children?: React.ReactNode;
-}) {
-  if (inline) {
-    return (
-      <code className="rounded bg-gray-200 px-1 py-0.5 text-sm">
-        {children}
-      </code>
-    );
-  }
-
-  return (
-    <pre className="overflow-x-auto rounded-md bg-gray-900 p-3 text-white">
-      <code className={className}>{children}</code>
-    </pre>
-  );
-}
-
-const components: Components = {
-  h1: ({ children }: any) => (
-    <h1 className="my-2 text-lg leading-tight font-semibold">{children}</h1>
-  ),
-  h2: ({ children }: any) => (
-    <h2 className="my-2 text-base leading-tight font-semibold">{children}</h2>
-  ),
-  h3: ({ children }: any) => (
-    <h3 className="my-2 text-base leading-tight font-semibold">{children}</h3>
-  ),
-  p: ({ children }: any) => <p className="my-2">{children}</p>,
-  ul: ({ children }: any) => (
-    <ul className="my-2 ml-5 list-disc space-y-1">{children}</ul>
-  ),
-  ol: ({ children }: any) => (
-    <ol className="my-2 ml-5 list-decimal space-y-1">{children}</ol>
-  ),
-  li: ({ children }: any) => <li className="leading-tight">{children}</li>,
-  code: CodeComponent as any
-};
-
 export default function Markdown({
   text,
   enableInsertForPython = false

--- a/src/contexts/NotebookContext.tsx
+++ b/src/contexts/NotebookContext.tsx
@@ -98,7 +98,7 @@ export function NotebookProvider({
   }, [getTrackerState, notebookTracker]);
 
   // Compose the full context (fields + function)
-  let fullContextValue: INotebookContext = {
+  const fullContextValue: INotebookContext = {
     ...contextValue,
     getNotebookJson
   };


### PR DESCRIPTION

https://github.com/user-attachments/assets/b1d0639f-f71a-4f10-8cf5-0096a02e074b

Inserts the code block right after the selected cell. Currently no limit as to how many times you can insert the code cell, which can be changed. Structure/design of the insert button and other elements up to debate as it sort of clashes with the standard markdown format.