### PR TITLE
feat: Changes to the new conversation button

### DIFF
--- a/src/AppWidget.tsx
+++ b/src/AppWidget.tsx
@@ -18,7 +18,7 @@ import { NotebookProvider } from '@/contexts/NotebookContext';
 
 // set the min-width to be same as the other default jupyterlab right sidebar
 // widgets (the property inspector and debugger, as of this writing)
-const APP_MIN_WIDTH = '250px';
+const APP_MIN_WIDTH = '300px';
 
 function App() {
   return (

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -83,7 +83,7 @@ export default function Chat() {
     <div className="flex h-full w-full flex-col gap-2">
       <div className="flex items-center justify-between gap-0.5 px-1">
         <Button
-          className="w-45 !rounded-full px-2 py-0.5"
+          className="w-50 px-2 py-0.5 text-xs"
           onClick={handleNewConversation}
           disabled={isWaiting}
         >


### PR DESCRIPTION
closes #29 

The button size kept getting overridden by the widget width, so I had to change the minimum from 250px to 300px

<img width="668" height="298" alt="image" src="https://github.com/user-attachments/assets/0f538f1b-dd52-446a-b46c-91360e0d3db5" />
