### PR TITLE
feat: Implemented list-files tool and search-files tool logic

### DIFF
--- a/dsc10_tutor_jlab_backend/file_tools.py
+++ b/dsc10_tutor_jlab_backend/file_tools.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+import json
+import tornado
+
+from jupyter_server.base.handlers import APIHandler
+
+WORKSPACE_ROOT = Path.cwd().resolve()
+ALLOWED_EXTENSIONS = {".ipynb", ".csv", ".md"}
+
+
+class ListFilesHandler(APIHandler):
+    @tornado.web.authenticated
+    def get(self):
+        path = self.get_query_argument("path", ".")
+        recursive = self.get_query_argument("recursive", "true").lower() == "true"
+
+        target = (WORKSPACE_ROOT / path).resolve()
+
+        # Safety check
+        try:
+            target.relative_to(WORKSPACE_ROOT)
+        except ValueError:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "Invalid path"}))
+            return
+
+        if not target.exists() or not target.is_dir():
+            self.finish(json.dumps({"files": []}))
+            return
+
+        files = []
+        iterator = target.rglob("*") if recursive else target.iterdir()
+
+        for item in iterator:
+            if item.is_file() and item.suffix in ALLOWED_EXTENSIONS:
+                files.append(
+                    {
+                        "path": str(item.relative_to(WORKSPACE_ROOT)),
+                        "type": (
+                            "notebook"
+                            if item.suffix == ".ipynb"
+                            else "data"
+                            if item.suffix == ".csv"
+                            else "text"
+                        ),
+                    }
+                )
+
+        self.finish(json.dumps({"files": files}))
+
+
+def python_search_files(query: str, scope: str = "."):
+    """
+    Search .ipynb files under `scope` for `query` (case-insensitive).
+    Returns a list of matching file paths.
+    """
+    base = (WORKSPACE_ROOT / scope).resolve()
+    matches = []
+
+    # Safety check: prevent escaping workspace
+    try:
+        base.relative_to(WORKSPACE_ROOT)
+    except ValueError:
+        return matches
+
+    if not base.exists():
+        return matches
+
+    for path in base.rglob("*.ipynb"):
+        if ".ipynb_checkpoints" in path.parts:
+            continue
+
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore").lower()
+            if query.lower() in text:
+                matches.append(str(path.relative_to(WORKSPACE_ROOT)))
+        except Exception:
+            continue
+
+    return matches
+
+
+class SearchFilesHandler(APIHandler):
+    @tornado.web.authenticated
+    def post(self):
+        """
+        POST /search-files
+        Body: { "query": "...", "scope": "." }
+        """
+        body = self.get_json_body() or {}
+
+        query = body.get("query", "").strip()
+        scope = body.get("scope", ".")
+
+        if not query:
+            self.finish(json.dumps({"files": []}))
+            return
+
+        files = python_search_files(query, scope)
+
+        self.finish(json.dumps({"files": files}))

--- a/dsc10_tutor_jlab_backend/handlers.py
+++ b/dsc10_tutor_jlab_backend/handlers.py
@@ -20,13 +20,13 @@ class RouteHandler(APIHandler):
 
 
 def setup_handlers(web_app):
-    # Example
-    # route_pattern = url_path_join(base_url, "dsc10-tutor-jlab-backend", "get-example")
-    # handlers = [(route_pattern, RouteHandler)]
-
     host_pattern = ".*$"
     base_url = web_app.settings["base_url"]
     handlers = [
+        (
+            url_path_join(base_url, "dsc10-tutor-jlab-backend", "get-example"),
+            RouteHandler,
+        ),
         (
             url_path_join(base_url, "dsc10-tutor-jlab-backend", "list-files"),
             ListFilesHandler,

--- a/dsc10_tutor_jlab_backend/handlers.py
+++ b/dsc10_tutor_jlab_backend/handlers.py
@@ -3,6 +3,8 @@ import json
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 import tornado
+from .file_tools import ListFilesHandler, SearchFilesHandler
+
 
 class RouteHandler(APIHandler):
     # The following decorator should be present on all verb methods (head, get, post,
@@ -10,15 +12,28 @@ class RouteHandler(APIHandler):
     # Jupyter server
     @tornado.web.authenticated
     def get(self):
-        self.finish(json.dumps({
-            "data": "This is /dsc10-tutor-jlab-backend/get-example endpoint!"
-        }))
+        self.finish(
+            json.dumps(
+                {"data": "This is /dsc10-tutor-jlab-backend/get-example endpoint!"}
+            )
+        )
 
 
 def setup_handlers(web_app):
-    host_pattern = ".*$"
+    # Example
+    # route_pattern = url_path_join(base_url, "dsc10-tutor-jlab-backend", "get-example")
+    # handlers = [(route_pattern, RouteHandler)]
 
+    host_pattern = ".*$"
     base_url = web_app.settings["base_url"]
-    route_pattern = url_path_join(base_url, "dsc10-tutor-jlab-backend", "get-example")
-    handlers = [(route_pattern, RouteHandler)]
+    handlers = [
+        (
+            url_path_join(base_url, "dsc10-tutor-jlab-backend", "list-files"),
+            ListFilesHandler,
+        ),
+        (
+            url_path_join(base_url, "dsc10-tutor-jlab-backend", "search-files"),
+            SearchFilesHandler,
+        ),
+    ]
     web_app.add_handlers(host_pattern, handlers)

--- a/dsc10_tutor_jlab_backend/tests/test_handlers.py
+++ b/dsc10_tutor_jlab_backend/tests/test_handlers.py
@@ -11,3 +11,39 @@ async def test_get_example(jp_fetch):
     assert payload == {
         "data": "This is /dsc10-tutor-jlab-backend/get-example endpoint!"
     }
+
+
+async def test_list_files(jp_fetch):
+    response = await jp_fetch("dsc10-tutor-jlab-backend", "list-files")
+
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert "files" in payload
+
+
+async def test_search_files_empty(jp_fetch):
+    response = await jp_fetch(
+        "dsc10-tutor-jlab-backend",
+        "search-files",
+        method="POST",
+        body=json.dumps({"query": "groupby"}),
+    )
+
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert "files" in payload
+
+
+async def test_search_files_finds_notebooks(jp_fetch):
+    response = await jp_fetch(
+        "dsc10-tutor-jlab-backend",
+        "search-files",
+        method="POST",
+        body=json.dumps({"query": "numpy", "scope": "."}),
+    )
+
+    assert response.code == 200
+    payload = json.loads(response.body)
+
+    assert "files" in payload
+    assert isinstance(payload["files"], list)


### PR DESCRIPTION
Implemented backend file discovery tools (list_files, search_files) for LLM integration.
Solves #43 

Two new API endpoints:

- `list_files`: recursively lists relevant files in a given scope
- `search_files`: searches file contents for a query string

Note: This PR only adds backend capabilities. Frontend wiring and LLM tool-calling logic (prompt + routing) will be handled in a separate PR

So, it needs to be tested with the frontend tool-calling implementation. 

For now, here's how to test the endpoint:
1) Start the jupyter server 
2) Call the endpoints directly in the dev tools console

3) Test both endpoints, (primarily edge case testing for search-files with specific keywords)
[xsrf token can be found after running "document.cookie"]

fetch("/dsc10-tutor-jlab-backend/search-files", {
  method: "POST",
  headers: {
    "Content-Type": "application/json",
    "X-XSRFToken": xsrf
  },
  credentials: "same-origin",
  body: JSON.stringify({ query: "array", scope: "." })
}).then(r => r.json()).then(console.log);